### PR TITLE
Cambiando el nombre de la base de datos a minúsculas

### DIFF
--- a/src/main/java/utilities/DatabaseConfig.java
+++ b/src/main/java/utilities/DatabaseConfig.java
@@ -2,6 +2,6 @@ package utilities;
 
 public interface DatabaseConfig {
 
-	public final String PersistenceUnit = "Deliberations";
+	public final String PersistenceUnit = "deliberations";
 	
 }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -14,13 +14,13 @@
 	xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
 	
-	<persistence-unit name="Deliberations">
+	<persistence-unit name="deliberations">
 
 		<!-- <provider>org.hibernate.ejb.HibernatePersistence</provider> -->
 		
 		<properties>
 			<property name="javax.persistence.jdbc.driver" value="com.mysql.jdbc.Driver" />
-			<property name="javax.persistence.jdbc.url" value="jdbc:mysql://localhost:3306/Deliberations" />
+			<property name="javax.persistence.jdbc.url" value="jdbc:mysql://localhost:3306/deliberations" />
 			<property name="javax.persistence.jdbc.user" value="acme-manager" />
 			<property name="javax.persistence.jdbc.password" value="ACME-M@n@ger-6874" />
 

--- a/src/main/resources/spring/config/data.xml
+++ b/src/main/resources/spring/config/data.xml
@@ -24,7 +24,7 @@
 	<bean id="dataSource" class="com.mchange.v2.c3p0.ComboPooledDataSource"
 		destroy-method="close">
 		<property name="driverClass" value="com.mysql.jdbc.Driver" />
-		<property name="jdbcUrl" value="jdbc:mysql://localhost:3306/Deliberations" />
+		<property name="jdbcUrl" value="jdbc:mysql://localhost:3306/deliberations" />
 		<property name="user" value="acme-user" />
 		<property name="password" value="ACME-Us3r-P@ssw0rd" />
 	</bean>
@@ -32,7 +32,7 @@
 	<!-- JPA -->
 
 	<bean id="persistenceUnit" class="java.lang.String">
-		<constructor-arg value="Deliberations" />
+		<constructor-arg value="deliberations" />
 	</bean>
 
 	<bean id="sqlDialect" class="java.lang.String">


### PR DESCRIPTION
Este cambio es necesario ya que la anterior configuración se aprovechaba de un bug concreto de la versión mysql utilizada